### PR TITLE
Prevent "Version mismatch" error

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
 ###> doctrine/doctrine-bundle ###


### PR DESCRIPTION
docker-compose.yaml uses version 3.7, so docker-compose isn't happy when we're using version 3 in the override. ;-)